### PR TITLE
remove sudo in `start-container.sh`

### DIFF
--- a/start-container.sh
+++ b/start-container.sh
@@ -11,23 +11,23 @@ fi
 	
 
 # delete old master container and start new master container
-sudo docker rm -f master &> /dev/null
+docker rm -f master &> /dev/null
 echo "start master container..."
-sudo docker run -d -t --dns 127.0.0.1 -P --name master -h master.kiwenlau.com -w /root kiwenlau/hadoop-master:0.1.0 &> /dev/null
+docker run -d -t --dns 127.0.0.1 -P --name master -h master.kiwenlau.com -w /root kiwenlau/hadoop-master:0.1.0 &> /dev/null
 
 # get the IP address of master container
-FIRST_IP=$(sudo docker inspect --format="{{.NetworkSettings.IPAddress}}" master)
+FIRST_IP=$(docker inspect --format="{{.NetworkSettings.IPAddress}}" master)
 
 # delete old slave containers and start new slave containers
 i=1
 while [ $i -lt $N ]
 do
-	sudo docker rm -f slave$i &> /dev/null
+	docker rm -f slave$i &> /dev/null
 	echo "start slave$i container..."
-	sudo docker run -d -t --dns 127.0.0.1 -P --name slave$i -h slave$i.kiwenlau.com -e JOIN_IP=$FIRST_IP kiwenlau/hadoop-slave:0.1.0 &> /dev/null
+	docker run -d -t --dns 127.0.0.1 -P --name slave$i -h slave$i.kiwenlau.com -e JOIN_IP=$FIRST_IP kiwenlau/hadoop-slave:0.1.0 &> /dev/null
 	i=$(( $i + 1 ))
 done 
 
 
 # create a new Bash session in the master container
-sudo docker exec -it master bash
+docker exec -it master bash


### PR DESCRIPTION
`sudo` in `start-container.sh` can create issue with environment that docker is deployed with normal user. If you use root as docker user, you can `sudo ./start-container.sh` instead of add `sudo` in `start-container.sh`.